### PR TITLE
fix: claude api error mapping

### DIFF
--- a/main.go
+++ b/main.go
@@ -100,6 +100,10 @@ func proxyToClaude(c *gin.Context, openAIReq OpenAIRequest) {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to parse response from Claude API"})
 		return
 	}
+	if claudeResp.Error != nil {
+		c.JSON(resp.StatusCode, gin.H{"error": OpenAIError{Type: claudeResp.Error.Type, Message: claudeResp.Error.Message}})
+		return
+	}
 
 	openAIResp := OpenAIResponse{
 		ID:      claudeResp.ID,

--- a/types.go
+++ b/types.go
@@ -48,6 +48,15 @@ type ClaudeAPIResponse struct {
 		InputTokens  int `json:"input_tokens"`
 		OutputTokens int `json:"output_tokens"`
 	} `json:"usage"`
+	Error *struct {
+		Type    string `json:"type"`
+		Message string `json:"message"`
+	} `json:"error,omitempty"`
+}
+
+type OpenAIError struct {
+	Type    string `json:"type"`
+	Message string `json:"message"`
 }
 
 type OpenAIResponse struct {
@@ -70,6 +79,7 @@ type OpenAIResponse struct {
 		CompletionTokens int `json:"completion_tokens"`
 		TotalTokens      int `json:"total_tokens"`
 	} `json:"usage"`
+	Error *OpenAIError `json:"error,omitempty"`
 }
 
 type OpenAIModel struct {


### PR DESCRIPTION
Try fix the error mapping from claude (stream=false):
```
{"type":"error","error":{"type":"rate_limit_error","message":"Number of requests has exceeded your per-minute rate limit (https://docs.anthropic.com/en/api/rate-limits); see the response headers for current usage. Please try again later or contact sales at https://www.anthropic.com/contact-sales to discuss your options for a rate limit increase."}}
```